### PR TITLE
Address feedback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Nim environment
-      uses: jiro4989/setup-nim-action@v1.1.2
+      uses: jiro4989/setup-nim-action@v1.1.3
       with:
         nim-version: ${{ matrix.nim }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         nim: [ 'devel', 'stable', '1.0.0' ]
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest' ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nimcache/
+.vscode/

--- a/src/tiny_sqlite.nim
+++ b/src/tiny_sqlite.nim
@@ -548,7 +548,7 @@ proc isAlive*(statement: SqlStatement): bool =
     (not SqlStatementImpl(statement).isNil) and (not statement.handle.isNil) and
         (not statement.db.handle.isNil)
 
-proc openDatabase*(path: string, mode = dbReadWrite, cacheSize: Natural = 50): DbConn =
+proc openDatabase*(path: string, mode = dbReadWrite, cacheSize: Natural = 100): DbConn =
     ## Open a new database connection to a database file. To create an
     ## in-memory database the special path `":memory:"` can be used.
     ## If the database doesn't already exist and ``mode`` is ``dbReadWrite``,

--- a/src/tiny_sqlite.nim
+++ b/src/tiny_sqlite.nim
@@ -5,6 +5,7 @@ from tiny_sqlite / sqlite_wrapper as sqlite import nil
 import tiny_sqlite / private / stmtcache
 
 when not declared(tupleLen):
+    import macros
     macro tupleLen(typ: typedesc[tuple]): int =
         let impl = getType(typ)
         result = newIntlitNode(impl[1].len - 1)

--- a/src/tiny_sqlite.nim
+++ b/src/tiny_sqlite.nim
@@ -9,7 +9,7 @@ when not declared(tupleLen):
         let impl = getType(typ)
         result = newIntlitNode(impl[1].len - 1)
 
-export options.get, options.isSome
+export options.get, options.isSome, options.isNone
 
 type
     DbConnImpl = ref object 

--- a/src/tiny_sqlite.nim
+++ b/src/tiny_sqlite.nim
@@ -1,12 +1,14 @@
 ## .. include:: ./tiny_sqlite/private/documentation.rst
 
-import std / [options, macros, typetraits, tables, sequtils]
+import std / [options, typetraits, tables, sequtils]
 from tiny_sqlite / sqlite_wrapper as sqlite import nil
 
 when not declared(tupleLen):
     macro tupleLen(typ: typedesc[tuple]): int =
         let impl = getType(typ)
         result = newIntlitNode(impl[1].len - 1)
+
+export options.get, options.isSome
 
 type
     DbConnImpl = ref object 
@@ -577,7 +579,7 @@ proc openDatabase*(path: string, mode = dbReadWrite, cacheSize: Natural = 100): 
 # ResultRow
 #
 
-proc `[]`*(row: ResultRow, idx: int): DbValue =
+proc `[]`*(row: ResultRow, idx: Natural): DbValue =
     ## Access a column in the result row based on index.
     row.values[idx]
 
@@ -585,7 +587,7 @@ proc `[]`*(row: ResultRow, column: string): DbValue =
     ## Access a column in te result row based on column name.
     ## The column name must be unambiguous.
     let idx = row.columns.find(column)
-    doAssert idx != -1, "Column does not exist in row: '" & column & "'"
+    assert idx != -1, "Column does not exist in row: '" & column & "'"
     doAssert count(row.columns, column) == 1, "Column exists multiple times in row: '" & column & "'"
     row.values[idx]
 

--- a/src/tiny_sqlite/private/documentation.rst
+++ b/src/tiny_sqlite/private/documentation.rst
@@ -53,7 +53,7 @@ Four different procedures for reading data are available:
 
 Note that the procedures `one` and `value` returns the result wrapped in an `Option`. See the standard library
 `options module <https://nim-lang.org/docs/options.html>`_ for documentation on how to deal with `Option` values.
-For convenience the `tiny_sqlite` module exports the `options.get` and `options.isSome` procedures so the options
+For convenience the `tiny_sqlite` module exports the `options.get`, `options.isSome`, and `options.isNone` procedures so the options
 module doesn't need to be explicitly imported for typical usage.
 
 .. code-block:: nim

--- a/src/tiny_sqlite/private/documentation.rst
+++ b/src/tiny_sqlite/private/documentation.rst
@@ -19,8 +19,9 @@ be created by using the special path `":memory:"` as an argument. Once the datab
 Executing SQL
 #############
 
-The `exec <#exec,DbConn,string,varargs[DbValue,toDbValue]>`_ procedure can be used to execute a single SQL statement. The `execScript <#execScript,DbConn,string>`_
-procedure is used to execute several statements, but it doesn't support parameter substitution.
+The `exec <#exec,DbConn,string,varargs[DbValue,toDbValue]>`_ procedure can be used to execute a single SQL statement.
+The `execScript <#execScript,DbConn,string>`_ procedure is used to execute several statements, but it doesn't support
+parameter substitution.
 
 .. code-block:: nim
 
@@ -50,6 +51,11 @@ Four different procedures for reading data are available:
 - `one <#one,DbConn,string,varargs[DbValue,toDbValue]>`_: procedure returning the first result row, or `none` if no result row exists
 - `value <#value,DbConn,string,varargs[DbValue,toDbValue]>`_: procedure returning the first column of the first result row, or `none` if no result row exists
 
+Note that the procedures `one` and `value` returns the result wrapped in an `Option`. See the standard library
+`options module <https://nim-lang.org/docs/options.html>`_ for documentation on how to deal with `Option` values.
+For convenience the `tiny_sqlite` module exports the `options.get` and `options.isSome` procedures so the options
+module doesn't need to be explicitly imported for typical usage.
+
 .. code-block:: nim
 
     for row in db.iterate("SELECT name, age FROM Person"):
@@ -74,8 +80,6 @@ Four different procedures for reading data are available:
     if value.isSome:
         echo fromDbValue(value.get, int) # Prints age of John Doe
 
-Note that the procedures `one` and `value` returns the result wrapped in an `Option`. See the standard library
-`options module <https://nim-lang.org/docs/options.html>`_ for documentation on how to deal with `Option` values.
 
 Inserting data in bulk
 ######################
@@ -124,10 +128,10 @@ The procedures that can execute multiple SQL statements (`execScript` and `execM
 Prepared statements
 ###################
 
-All the procedures described above operate directly on the database connection. In addition to those procedures,
-``tiny_sqlite`` also offer an API for preparing SQL statements in advance. Prepared statements are created with the
-`stmt <#stmt,DbConn,string>`_ procedure, and the same procedures for executing SQL that are available directly
-on the connection object are also available for the prepared statement:
+All the procedures for executing SQL described above creates and executes prepared statements internally. In addition to
+those procedures, ``tiny_sqlite`` also offers an API for preparing SQL statements explicitly. Prepared statements are
+created with the `stmt <#stmt,DbConn,string>`_ procedure, and the same procedures for executing SQL that are available
+directly on the connection object are also available for the prepared statement:
 
 
 .. code-block:: nim

--- a/src/tiny_sqlite/private/documentation.rst
+++ b/src/tiny_sqlite/private/documentation.rst
@@ -128,7 +128,7 @@ The procedures that can execute multiple SQL statements (`execScript` and `execM
 Prepared statements
 ###################
 
-All the procedures for executing SQL described above creates and executes prepared statements internally. In addition to
+All the procedures for executing SQL described above create and execute prepared statements internally. In addition to
 those procedures, ``tiny_sqlite`` also offers an API for preparing SQL statements explicitly. Prepared statements are
 created with the `stmt <#stmt,DbConn,string>`_ procedure, and the same procedures for executing SQL that are available
 directly on the connection object are also available for the prepared statement:

--- a/src/tiny_sqlite/private/stmtcache.nim
+++ b/src/tiny_sqlite/private/stmtcache.nim
@@ -1,0 +1,81 @@
+## Implements a least-recently-used cache for prepared statements based on
+## https://github.com/jackhftang/lrucache.nim.
+
+import std / [lists, tables]
+from .. / sqlite_wrapper as sqlite import nil
+
+type
+  Node = object
+    key: string
+    val: sqlite.Stmt
+
+  StmtCache* = object 
+    capacity: int
+    list: DoublyLinkedList[Node]
+    table: Table[string, DoublyLinkedNode[Node]]
+
+proc initStmtCache*(capacity: Natural): StmtCache =
+  ## Create a new Least-Recently-Used (LRU) cache that store the last `capacity`-accessed items.
+  StmtCache(
+    capacity: capacity,
+    list: initDoublyLinkedList[Node](),
+    table: initTable[string, DoublyLinkedNode[Node]](rightSize(capacity))
+  )
+
+proc resize(cache: var StmtCache) =
+  while cache.table.len > cache.capacity:
+    let t = cache.list.tail
+    cache.table.del(t.value.key)
+    discard sqlite.finalize(t.value.val)
+    cache.list.remove t
+
+proc capacity*(cache: StmtCache): int = 
+  ## Get the maximum capacity of cache
+  cache.capacity
+
+proc len*(cache: StmtCache): int = 
+  ## Return number of keys in cache
+  cache.table.len
+
+proc contains*(cache: StmtCache, key: string): bool =
+  ## Check whether key in cache. Does *NOT* update recentness.
+  cache.table.contains(key)
+
+proc clear*(cache: var StmtCache) =
+  ## remove all items
+  cache.list = initDoublyLinkedList[Node]()
+  cache.table.clear()
+
+proc `[]`*(cache: var StmtCache, key: string): sqlite.Stmt =
+  ## Read value from `cache` by `key` and update recentness
+  ## Raise `KeyError` if `key` is not in `cache`.
+  let node = cache.table[key]
+  result = node.value.val
+  cache.list.remove node
+  cache.list.prepend node
+
+proc `[]=`*(cache: var StmtCache, key: string, val: sqlite.Stmt) =
+  ## Put value `v` in cache with key `k`.
+  ## Remove least recently used value from cache if length exceeds capacity.
+  var node = cache.table.getOrDefault(key, nil)
+  if node.isNil:
+    let node = newDoublyLinkedNode[Node](
+      Node(key: key, val: val)
+    )
+    cache.table[key] = node
+    cache.list.prepend node
+    cache.resize()
+  else:
+    # set value 
+    node.value.val = val
+    # move to head
+    cache.list.remove node
+    cache.list.prepend node
+    
+proc getOrDefault*(cache: StmtCache, key: string, val: sqlite.Stmt = nil): sqlite.Stmt =
+  ## Similar to get, but return `val` if `key` is not in `cache`
+  let node = cache.table.getOrDefault(key, nil)
+  if node.isNil:
+    result = val
+  else:
+    result = node.value.val


### PR DESCRIPTION
PR addresses the feedback from #6 

> Is there a reason why anyone would want to use fromDbValue(int) instead of .intVal? One of the things that's a bit confusing is there are several ways to do the same thing, which raises the question "why would I want to use x instead of y?" Plus one way uses int and the other uses intVal. It would be simpler to just use .int (fewer things to remember), but maybe that's not possible. And if it's not ever necessary to use fromDbValue(int), I'd leave it out because it's a pain to type vs .intVal.

The motivation for `fromDbValue` is support for more complex types. For example, `fromDbValue(row[0], bool)` and 
`fromDbValue(row[0], Option[int])` both works out of the box. The idea is also that the user can extend the behavior
of `unpack`, for example if the user has implemented the proper overload of `fromDbValue` then
`unpack(row, tuple[timestamp: times.Time])` will be valid.

> As a more general thing, I like how Nim can generate details documentation from source. But it does that based on the topological order required by the Nim compiler: imports, types, and procs, all ordered from "least dependencies" to "most dependencies", ie, bottom-up. But most people tend to grasp ideas better when higher-level concepts are presented first, with lower-level concepts (like the 13 dbFrom/ToValues) presented last. Maybe there is some automagic way the documentation could be reordered to be top-down, from most dependencies to least dependencies. Just an idea - might work, might not.

This bothers me to, but I don't know any way around it (other than adding a ton of forward declarations). [Nim's stdlib struggles with this as well](https://github.com/nim-lang/Nim/issues/9102)

> the docs say to see the options module (which I admit I didn't go read; I was just trying to go by the examples), but I didn't realize that I needed to import options, because I am neoNim. I don't know if it makes sense for import tiny_sqlite to shove the options module into my namespace (with export?), or maybe just add a note that the options module must also be imported with iny_sqlite for the dummies like me

I've now added a re-export of just the `options.get` and `options.isSome` procedures, which I think should be all that's needed for most use cases.

> I said I didn't think an LRU cache was worth it but now have changed my mind based on tests and think tiny_sqlite should use LruCache instead of OT.

I agree, I've now switched to a LRU cache based on jackhftang/lrucache.nim