### PR TITLE
Support loading SQLite extensions

### DIFF
--- a/src/tiny_sqlite/sqlite_wrapper.nim
+++ b/src/tiny_sqlite/sqlite_wrapper.nim
@@ -154,6 +154,9 @@ proc open*(filename: cstring, db: var Sqlite3): cint
 proc open_v2*(filename: cstring, db: var Sqlite3, flags: cint, zVfsName: cstring ): cint
     {.cdecl, dynlib: Lib, importc: "sqlite3_open_v2".}
 
+proc enable_load_extension*(db: Sqlite3, onoff: cint): cint
+    {.cdecl, dynlib: Lib, importc: "sqlite3_enable_load_extension".}
+
 proc errcode*(db: Sqlite3): cint
     {.cdecl, dynlib: Lib, importc: "sqlite3_errcode".}
 

--- a/src/tiny_sqlite/sqlite_wrapper.nim
+++ b/src/tiny_sqlite/sqlite_wrapper.nim
@@ -157,6 +157,12 @@ proc open_v2*(filename: cstring, db: var Sqlite3, flags: cint, zVfsName: cstring
 proc enable_load_extension*(db: Sqlite3, onoff: cint): cint
     {.cdecl, dynlib: Lib, importc: "sqlite3_enable_load_extension".}
 
+proc load_extension*(db: Sqlite3, filename: cstring, entry: cstring, error: ptr cstring): cint
+    {.cdecl, dynlib: Lib, importc: "sqlite3_load_extension".}
+
+proc free*(z: cstring)
+    {.cdecl, dynlib: Lib, importc: "sqlite3_free".}
+
 proc errcode*(db: Sqlite3): cint
     {.cdecl, dynlib: Lib, importc: "sqlite3_errcode".}
 


### PR DESCRIPTION
Thanks for a great library.

This PR allows [SQLite extensions](https://www.sqlite.org/c3ref/load_extension.html) to be loaded:
```nim
let db = openDatabase("path")
db.loadExtension("extension/path")
```

It doesn't currently implement the entry point concept. Also SQLite 3.37.2 seems not to return an error message (`**pzErrMsg`) when it can't find the extension, but the code's ready if it did (subject to my having understood the c interop correctly).

If the system `libsqlite3` is built with [`SQLITE_OMIT_LOAD_EXTENSION`](https://github.com/sqlite/sqlite/search?q=SQLITE_OMIT_LOAD_EXTENSION), it seems to be possible to use a different one with nim compiler options `--dynlibOverride:libsqlite3` and `--passL:"-L/path/to/sqlite/lib -lsqlite3"`.